### PR TITLE
Fix bug: saving in a plain CSS inline editor generates copy of CSS file

### DIFF
--- a/main.js
+++ b/main.js
@@ -105,7 +105,7 @@ define(function (require, exports, module) {
 
   // Register for documentSaved events to support inline-editors
   $(DocumentManager).on('documentSaved', function (event, document) {
-  	if (EditorManager.getCurrentFullEditor().document !== document) {
+  	if (EditorManager.getCurrentFullEditor().document !== document && document.getLanguage().getId() === 'less') {
   		compileLess(document.getText(), document.file.fullPath);
   	}
   });


### PR DESCRIPTION
Saving in a CSS inline editor was running `compileLess()` even though it's not a LESS file (generating a "compiled" copy of the CSS file with one letter missing from its filename).

This bug could also have other symptoms in other cases, e.g. saving in a JS inline editor or saving many files at once via Save All could try to "compile" files of all sorts of other types too.
