### PR TITLE
autoprefixer error message

### DIFF
--- a/main.js
+++ b/main.js
@@ -74,6 +74,7 @@ define(function (require, exports, module) {
   }
 
   function convertError(error) {
+    if(typeof error === 'string') return { pos: {}, message: error };
     switch (error.code) {
     case 'EACCES':
     case 'ENOENT':


### PR DESCRIPTION
A faulty configuration line like this:

```javascript
// autoprefixer: last 2 ersions
```

Would result in an error like this:
```
Error in file 'undefined' on line undefined: undefined
```

This little change will turn it into this:
```
Unknown browser query `last 2 ersions`
```

But I'm not sure if its a good idea to treat all error messages this way...

