### PR TITLE
Update LessCompiler.js

### DIFF
--- a/node/LessCompiler.js
+++ b/node/LessCompiler.js
@@ -115,7 +115,7 @@ function compile(lessFile, callback) {
     if (options.autoprefixer) {
       var autoprefixerOptions = {};
       if (typeof options.autoprefixer === 'string') {
-        autoprefixerOptions.browsers = [options.autoprefixer];
+        autoprefixerOptions.browsers = options.autoprefixer.split(';');
       }
       options.plugins.push(new LessPluginAutoPrefix(autoprefixerOptions));
     }


### PR DESCRIPTION
I suggest to add a simple code update to support more parameters in autoprefixer options.
The parameter can be separated with ;

... strictMath: true, autoprefixer: Android 2.3;Android >= 4;Chrome >= 20;Firefox >= 24;Explorer >= 8;iOS >= 6;Opera >= 12;Safari >= 6