### PR TITLE
Use Project-wide Compile Options for all options

### DIFF
--- a/example/compile.json
+++ b/example/compile.json
@@ -1,0 +1,3 @@
+{
+    "compress": true
+}

--- a/node/LessCompiler.js
+++ b/node/LessCompiler.js
@@ -7,7 +7,7 @@ var LessPluginCleanCSS = require('less-plugin-clean-css');
 var path = require('path');
 var fs = require('fs');
 var mkpath = require('mkpath');
-var extend = require('extend');
+var extend = require('util')._extend;
 
 function readOptions(content) {
   var firstLine = content.substr(0, content.indexOf('\n'));
@@ -52,7 +52,7 @@ function compile(lessFile, defaults, callback) {
     }
 
     var content = buffer.toString();
-    var options = extend({}, defaults, readOptions(content));
+    var options = extend(defaults, readOptions(content));
     var lessPath = path.dirname(lessFile);
     var cssFilename;
     var cssFile;

--- a/node/LessCompiler.js
+++ b/node/LessCompiler.js
@@ -52,7 +52,7 @@ function compile(lessFile, defaults, callback) {
     }
 
     var content = buffer.toString();
-    var options = extend(defaults, readOptions(content));
+    var options = extend(extend({}, defaults), readOptions(content));
     var lessPath = path.dirname(lessFile);
     var cssFilename;
     var cssFile;
@@ -60,8 +60,8 @@ function compile(lessFile, defaults, callback) {
     // main is set: compile the referenced file instead
     if (options.main) {
       lessFile = path.resolve(lessPath, options.main);
-      return compile(lessFile, callback);
-    }
+      return compile(lessFile, defaults, callback);
+    } 
 
     // out is null or false: do not compile
     if (options.out === null || options.out === false) {

--- a/node/LessCompiler.js
+++ b/node/LessCompiler.js
@@ -7,6 +7,7 @@ var LessPluginCleanCSS = require('less-plugin-clean-css');
 var path = require('path');
 var fs = require('fs');
 var mkpath = require('mkpath');
+var extend = require('extend');
 
 function readOptions(content) {
   var firstLine = content.substr(0, content.indexOf('\n'));
@@ -43,15 +44,15 @@ function mkfile(filepath, content, callback) {
 }
 
 // compile the given less file
-function compile(lessFile, callback) {
-
+function compile(lessFile, defaults, callback) {
+    
   fs.readFile(lessFile, function (err, buffer) {
     if (err) {
       return callback(err);
     }
 
     var content = buffer.toString();
-    var options = readOptions(content);
+    var options = extend({}, defaults, readOptions(content));
     var lessPath = path.dirname(lessFile);
     var cssFilename;
     var cssFile;


### PR DESCRIPTION
This PR addresses some of the feature enhancement expressed in #51. Especially with the introduction of autoprefixer i find it difficult to write its configurations in each and every less file and maintain any changes. Therefore i extended the functionality of the plugin to load the options from the configuration files and forward them to the compiler. There, the options are merged and overridden with those from the first comment line.

I you find any issues, let me know, and i can fix them.
